### PR TITLE
Added CSS to improve layout of Amanda Loudin article.

### DIFF
--- a/Amanda_Loudin.html
+++ b/Amanda_Loudin.html
@@ -9,6 +9,7 @@ xmlns="http://www.w3.org/TR/REC-html40">
 <meta name=ProgId content=Word.Document>
 <meta name=Generator content="Microsoft Word 14">
 <meta name=Originator content="Microsoft Word 14">
+<link rel="stylesheet" type="text/css" href="article.css">
 <link rel=File-List href="Amanda_Loudin_files/filelist.xml">
 <title>Putting Your Head In the Game</title>
 <!--[if gte mso 9]><xml>

--- a/article.css
+++ b/article.css
@@ -1,0 +1,9 @@
+div.WordSection1 {
+  column-width: 20em;
+}
+div.WordSection1 p:first-child, div.WordSection1 p:nth-child(2) {
+  column-span: all;
+}
+div.WordSection1 p:first-child span:nth-child(2) {
+  display: block;
+}


### PR DESCRIPTION
Added a multi-column layout so that individual paragraphs don't run the full width of a large browser window, which makes the paragraphs easier to read and look more like a newspaper article. Broke up the "Health & Science" header from the story headline.